### PR TITLE
Remove obsolete credentials

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,8 +2,6 @@
 
 [app]
 address = "0.0.0.0:9000"
-admin_password = "listmonk"
-admin_username = "listmonk"
 
 [db]
 database = "postgres"

--- a/fly.toml
+++ b/fly.toml
@@ -7,8 +7,6 @@ primary_region = 'dfw'
 
 [env]
   LISTMONK_app__address = "0.0.0.0:8080"
-  # LISTMONK_app__admin_password = ""
-  LISTMONK_app__admin_username = "listmonk"
   LISTMONK_db__database = "haskellweekly_listmonk"
   LISTMONK_db__host = "haskellweekly-postgres.flycast"
   # LISTMONK_db__password = ""


### PR DESCRIPTION
These are unnecessary after upgrading to listmonk 4.1.0 (#5).